### PR TITLE
Add WebGL2 support for new renderer system

### DIFF
--- a/src/WEBGL2Renderer.ts
+++ b/src/WEBGL2Renderer.ts
@@ -1,0 +1,268 @@
+import { IRenderer, RendererStatus, RendererConfig, AtlasMetadata, LayerConfig, RendererError } from "./interfaces/IRenderer";
+import { mat4 } from "gl-matrix";
+
+export class WEBGL2Renderer implements IRenderer {
+    private canvas: HTMLCanvasElement;
+    private gl: WebGL2RenderingContext;
+    private grid_size: number;
+    private total_tiles: number;
+    private projMatrix: mat4;
+    private viewMatrix: mat4;
+    private vertexBuffer: WebGLBuffer | null = null;
+    private tiledataBuffer: WebGLBuffer | null = null;
+    private atlasTexture: WebGLTexture | null = null;
+    private program: WebGLProgram | null = null;
+    private locations: any = {};
+
+    constructor(canvas: HTMLCanvasElement, grid_size: number) {
+        this.canvas = canvas;
+        this.grid_size = grid_size;
+        this.total_tiles = grid_size * grid_size;
+        this.gl = canvas.getContext('webgl2') as WebGL2RenderingContext;
+
+        if (!this.gl) {
+            console.error('WebGL2 not supported');
+            return;
+        }
+
+        this.projMatrix = mat4.create();
+        this.viewMatrix = mat4.create();
+
+        mat4.perspective(this.projMatrix, 60 * Math.PI / 180, this.canvas.width / this.canvas.height, 0.1, 100.0);
+
+        mat4.lookAt(this.viewMatrix,
+            [this.grid_size / 2, -this.grid_size, this.grid_size / 2], // camera position
+            [this.grid_size / 2, this.grid_size / 2, 0], // look at point
+            [0, 0, 1] // up vector
+        );
+
+        this.gl.enable(this.gl.DEPTH_TEST);
+        this.gl.enable(this.gl.BLEND);
+        this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
+        this.handleResize();
+    }
+
+    static isSupported(): boolean {
+        const dummyCanvas = document.createElement('canvas');
+        document.body.appendChild(dummyCanvas);
+        const supported = !!dummyCanvas.getContext('webgl2');
+        document.body.removeChild(dummyCanvas);
+        return supported;
+    }
+
+    async setup(atlasTexture: HTMLImageElement): Promise<void> {
+        this.createBuffers();
+        this.setupTexture(atlasTexture);
+        this.createShaders();
+
+        this.gl.useProgram(this.program);
+        this.gl.uniformMatrix4fv(this.locations.projectionMatrix, false, this.projMatrix);
+        this.gl.uniformMatrix4fv(this.locations.viewMatrix, false, this.viewMatrix);
+        this.gl.uniform2f(this.locations.gridSize, this.grid_size, this.grid_size);
+
+        this.gl.activeTexture(this.gl.TEXTURE0);
+        this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture);
+        this.gl.uniform1i(this.locations.atlas, 0);
+    }
+
+    private createBuffers(): void {
+        const vertices = new Float32Array([
+            0.0, 0.0, 0.0,  // Bottom left
+            1.0, 0.0, 0.0,  // Bottom right
+            1.0, 1.0, 0.0,  // Top right
+            0.0, 0.0, 0.0,  // Bottom left
+            1.0, 1.0, 0.0,  // Top right
+            0.0, 1.0, 0.0   // Top left
+        ]);
+
+        this.vertexBuffer = this.gl.createBuffer();
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, vertices, this.gl.STATIC_DRAW);
+
+        this.tiledataBuffer = this.gl.createBuffer();
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.tiledataBuffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, new Uint8Array(this.total_tiles), this.gl.DYNAMIC_DRAW);
+    }
+
+    private setupTexture(atlas: HTMLImageElement): void {
+        this.atlasTexture = this.gl.createTexture();
+        this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture);
+
+        this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, atlas);
+
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+    }
+
+    private createShaders(): void {
+        const vsSource = `#version 300 es
+            in vec3 aPosition;
+            in float aTileId;
+
+            uniform mat4 uProjectionMatrix;
+            uniform mat4 uViewMatrix;
+            uniform vec2 uGridSize;
+
+            out vec2 vTexCoord;
+
+            void main() {
+                float instance = float(gl_InstanceID);
+                float x = mod(instance, uGridSize.x);
+                float y = floor(instance / uGridSize.x);
+
+                vec3 worldPos = vec3(
+                    aPosition.x + x,
+                    aPosition.y + y,
+                    0.0
+                );
+
+                gl_Position = uProjectionMatrix * uViewMatrix * vec4(worldPos, 1.0);
+
+                float atlasSize = 4.0;
+                float tileX = mod(aTileId, atlasSize);
+                float tileY = floor(aTileId / atlasSize);
+
+                vec2 tileCoord = vec2(
+                    (tileX + mod(aPosition.x, 1.0)) / atlasSize,
+                    (tileY + mod(aPosition.y, 1.0)) / atlasSize
+                );
+
+                vTexCoord = tileCoord;
+            }
+        `;
+
+        const fsSource = `#version 300 es
+            precision mediump float;
+
+            in vec2 vTexCoord;
+            uniform sampler2D uAtlas;
+
+            out vec4 fragColor;
+
+            void main() {
+                fragColor = texture(uAtlas, vTexCoord);
+            }
+        `;
+
+        const vertexShader = this.createShader(this.gl.VERTEX_SHADER, vsSource);
+        const fragmentShader = this.createShader(this.gl.FRAGMENT_SHADER, fsSource);
+
+        this.program = this.gl.createProgram();
+        this.gl.attachShader(this.program, vertexShader);
+        this.gl.attachShader(this.program, fragmentShader);
+        this.gl.linkProgram(this.program);
+
+        if (!this.gl.getProgramParameter(this.program, this.gl.LINK_STATUS)) {
+            console.error('Program link error:', this.gl.getProgramInfoLog(this.program));
+            return;
+        }
+
+        this.locations = {
+            position: this.gl.getAttribLocation(this.program, 'aPosition'),
+            tileId: this.gl.getAttribLocation(this.program, 'aTileId'),
+            projectionMatrix: this.gl.getUniformLocation(this.program, 'uProjectionMatrix'),
+            viewMatrix: this.gl.getUniformLocation(this.program, 'uViewMatrix'),
+            gridSize: this.gl.getUniformLocation(this.program, 'uGridSize'),
+            atlas: this.gl.getUniformLocation(this.program, 'uAtlas')
+        };
+    }
+
+    private createShader(type: number, source: string): WebGLShader | null {
+        const shader = this.gl.createShader(type);
+        this.gl.shaderSource(shader, source);
+        this.gl.compileShader(shader);
+
+        if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
+            console.error('Shader compile error:', this.gl.getShaderInfoLog(shader));
+            this.gl.deleteShader(shader);
+            return null;
+        }
+        return shader;
+    }
+
+    updateGridData(data: Uint8Array): void {
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.tiledataBuffer);
+        this.gl.bufferSubData(this.gl.ARRAY_BUFFER, 0, data);
+    }
+
+    handleResize(): void {
+        const displayWidth = this.canvas.clientWidth;
+        const displayHeight = this.canvas.clientHeight;
+        if (this.canvas.width !== displayWidth || this.canvas.height !== displayHeight) {
+            this.canvas.width = displayWidth;
+            this.canvas.height = displayHeight;
+            this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
+
+            mat4.perspective(this.projMatrix, 60 * Math.PI / 180, this.canvas.width / this.canvas.height, 0.1, 100.0);
+
+            if (this.program) {
+                this.gl.useProgram(this.program);
+                this.gl.uniformMatrix4fv(this.locations.projectionMatrix, false, this.projMatrix);
+            }
+        }
+    }
+
+    draw(): void {
+        this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
+        this.gl.useProgram(this.program);
+
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        this.gl.enableVertexAttribArray(this.locations.position);
+        this.gl.vertexAttribPointer(this.locations.position, 3, this.gl.FLOAT, false, 0, 0);
+        this.gl.vertexAttribDivisor(this.locations.position, 0);
+
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.tiledataBuffer);
+        this.gl.enableVertexAttribArray(this.locations.tileId);
+        this.gl.vertexAttribPointer(this.locations.tileId, 1, this.gl.UNSIGNED_BYTE, false, 0, 0);
+        this.gl.vertexAttribDivisor(this.locations.tileId, 1);
+
+        this.gl.drawArraysInstanced(this.gl.TRIANGLES, 0, 6, this.total_tiles);
+    }
+
+    dispose(): void {
+        if (!this.gl) return;
+
+        if (this.vertexBuffer) this.gl.deleteBuffer(this.vertexBuffer);
+        if (this.tiledataBuffer) this.gl.deleteBuffer(this.tiledataBuffer);
+        if (this.atlasTexture) this.gl.deleteTexture(this.atlasTexture);
+
+        if (this.program) {
+            const shaders = this.gl.getAttachedShaders(this.program);
+            if (shaders) {
+                shaders.forEach(shader => {
+                    this.gl.deleteShader(shader);
+                });
+            }
+            this.gl.deleteProgram(this.program);
+        }
+
+        this.vertexBuffer = null;
+        this.tiledataBuffer = null;
+        this.atlasTexture = null;
+        this.program = null;
+        this.locations = null;
+
+        if (this.gl) {
+            this.gl.clearColor(0, 0, 0, 1);
+            this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
+
+            if (this.gl.getExtension('WEBGL_lose_context')) {
+                this.gl.getExtension('WEBGL_lose_context').loseContext();
+            }
+        }
+        this.gl = null;
+    }
+
+    status: RendererStatus = RendererStatus.Uninitialized;
+    lastError: RendererError | null = null;
+
+    on(event: "error" | "ready" | "disposed", callback: (data?: any) => void): void {
+        throw new Error("Method not implemented.");
+    }
+
+    off(event: string, callback: (data?: any) => void): void {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/src/WEBGL2TerrainPass.ts
+++ b/src/WEBGL2TerrainPass.ts
@@ -1,0 +1,240 @@
+import { mat4 } from "gl-matrix";
+
+export class WEBGL2TerrainPass extends EventTarget {
+    private gl: WebGL2RenderingContext;
+    private gridSize: number;
+    private vertexBuffer: WebGLBuffer | null = null;
+    private tiledataBuffer: WebGLBuffer | null = null;
+    private atlasTexture: WebGLTexture | null = null;
+    private program: WebGLProgram | null = null;
+    private locations: any = {};
+    private projMatrix: mat4;
+    private viewMatrix: mat4;
+
+    constructor(gl: WebGL2RenderingContext, gridSize: number) {
+        super();
+        this.gl = gl;
+        this.gridSize = gridSize;
+
+        this.projMatrix = mat4.create();
+        this.viewMatrix = mat4.create();
+
+        mat4.perspective(this.projMatrix, 60 * Math.PI / 180, this.gl.canvas.width / this.gl.canvas.height, 0.1, 100.0);
+
+        mat4.lookAt(this.viewMatrix,
+            [this.gridSize / 2, -this.gridSize, this.gridSize / 2], // camera position
+            [this.gridSize / 2, this.gridSize / 2, 0], // look at point
+            [0, 0, 1] // up vector
+        );
+
+        this.gl.enable(this.gl.DEPTH_TEST);
+        this.gl.enable(this.gl.BLEND);
+        this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
+        this.handleResize();
+    }
+
+    async setup(atlasTexture: HTMLImageElement): Promise<void> {
+        this.createBuffers();
+        this.setupTexture(atlasTexture);
+        this.createShaders();
+
+        this.gl.useProgram(this.program);
+        this.gl.uniformMatrix4fv(this.locations.projectionMatrix, false, this.projMatrix);
+        this.gl.uniformMatrix4fv(this.locations.viewMatrix, false, this.viewMatrix);
+        this.gl.uniform2f(this.locations.gridSize, this.gridSize, this.gridSize);
+
+        this.gl.activeTexture(this.gl.TEXTURE0);
+        this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture);
+        this.gl.uniform1i(this.locations.atlas, 0);
+    }
+
+    private createBuffers(): void {
+        const vertices = new Float32Array([
+            0.0, 0.0, 0.0,  // Bottom left
+            1.0, 0.0, 0.0,  // Bottom right
+            1.0, 1.0, 0.0,  // Top right
+            0.0, 0.0, 0.0,  // Bottom left
+            1.0, 1.0, 0.0,  // Top right
+            0.0, 1.0, 0.0   // Top left
+        ]);
+
+        this.vertexBuffer = this.gl.createBuffer();
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, vertices, this.gl.STATIC_DRAW);
+
+        this.tiledataBuffer = this.gl.createBuffer();
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.tiledataBuffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, new Uint8Array(this.gridSize * this.gridSize), this.gl.DYNAMIC_DRAW);
+    }
+
+    private setupTexture(atlas: HTMLImageElement): void {
+        this.atlasTexture = this.gl.createTexture();
+        this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture);
+
+        this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, atlas);
+
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+    }
+
+    private createShaders(): void {
+        const vsSource = `#version 300 es
+            in vec3 aPosition;
+            in float aTileId;
+
+            uniform mat4 uProjectionMatrix;
+            uniform mat4 uViewMatrix;
+            uniform vec2 uGridSize;
+
+            out vec2 vTexCoord;
+
+            void main() {
+                float instance = float(gl_InstanceID);
+                float x = mod(instance, uGridSize.x);
+                float y = floor(instance / uGridSize.x);
+
+                vec3 worldPos = vec3(
+                    aPosition.x + x,
+                    aPosition.y + y,
+                    0.0
+                );
+
+                gl_Position = uProjectionMatrix * uViewMatrix * vec4(worldPos, 1.0);
+
+                float atlasSize = 4.0;
+                float tileX = mod(aTileId, atlasSize);
+                float tileY = floor(aTileId / atlasSize);
+
+                vec2 tileCoord = vec2(
+                    (tileX + mod(aPosition.x, 1.0)) / atlasSize,
+                    (tileY + mod(aPosition.y, 1.0)) / atlasSize
+                );
+
+                vTexCoord = tileCoord;
+            }
+        `;
+
+        const fsSource = `#version 300 es
+            precision mediump float;
+
+            in vec2 vTexCoord;
+            uniform sampler2D uAtlas;
+
+            out vec4 fragColor;
+
+            void main() {
+                fragColor = texture(uAtlas, vTexCoord);
+            }
+        `;
+
+        const vertexShader = this.createShader(this.gl.VERTEX_SHADER, vsSource);
+        const fragmentShader = this.createShader(this.gl.FRAGMENT_SHADER, fsSource);
+
+        this.program = this.gl.createProgram();
+        this.gl.attachShader(this.program, vertexShader);
+        this.gl.attachShader(this.program, fragmentShader);
+        this.gl.linkProgram(this.program);
+
+        if (!this.gl.getProgramParameter(this.program, this.gl.LINK_STATUS)) {
+            console.error('Program link error:', this.gl.getProgramInfoLog(this.program));
+            return;
+        }
+
+        this.locations = {
+            position: this.gl.getAttribLocation(this.program, 'aPosition'),
+            tileId: this.gl.getAttribLocation(this.program, 'aTileId'),
+            projectionMatrix: this.gl.getUniformLocation(this.program, 'uProjectionMatrix'),
+            viewMatrix: this.gl.getUniformLocation(this.program, 'uViewMatrix'),
+            gridSize: this.gl.getUniformLocation(this.program, 'uGridSize'),
+            atlas: this.gl.getUniformLocation(this.program, 'uAtlas')
+        };
+    }
+
+    private createShader(type: number, source: string): WebGLShader | null {
+        const shader = this.gl.createShader(type);
+        this.gl.shaderSource(shader, source);
+        this.gl.compileShader(shader);
+
+        if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
+            console.error('Shader compile error:', this.gl.getShaderInfoLog(shader));
+            this.gl.deleteShader(shader);
+            return null;
+        }
+        return shader;
+    }
+
+    updateGridData(data: Uint8Array): void {
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.tiledataBuffer);
+        this.gl.bufferSubData(this.gl.ARRAY_BUFFER, 0, data);
+    }
+
+    handleResize(): void {
+        const displayWidth = this.gl.canvas.clientWidth;
+        const displayHeight = this.gl.canvas.clientHeight;
+        if (this.gl.canvas.width !== displayWidth || this.gl.canvas.height !== displayHeight) {
+            this.gl.canvas.width = displayWidth;
+            this.gl.canvas.height = displayHeight;
+            this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
+
+            mat4.perspective(this.projMatrix, 60 * Math.PI / 180, this.gl.canvas.width / this.gl.canvas.height, 0.1, 100.0);
+
+            if (this.program) {
+                this.gl.useProgram(this.program);
+                this.gl.uniformMatrix4fv(this.locations.projectionMatrix, false, this.projMatrix);
+            }
+        }
+    }
+
+    draw(): void {
+        this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
+        this.gl.useProgram(this.program);
+
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        this.gl.enableVertexAttribArray(this.locations.position);
+        this.gl.vertexAttribPointer(this.locations.position, 3, this.gl.FLOAT, false, 0, 0);
+        this.gl.vertexAttribDivisor(this.locations.position, 0);
+
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.tiledataBuffer);
+        this.gl.enableVertexAttribArray(this.locations.tileId);
+        this.gl.vertexAttribPointer(this.locations.tileId, 1, this.gl.UNSIGNED_BYTE, false, 0, 0);
+        this.gl.vertexAttribDivisor(this.locations.tileId, 1);
+
+        this.gl.drawArraysInstanced(this.gl.TRIANGLES, 0, 6, this.gridSize * this.gridSize);
+    }
+
+    dispose(): void {
+        if (!this.gl) return;
+
+        if (this.vertexBuffer) this.gl.deleteBuffer(this.vertexBuffer);
+        if (this.tiledataBuffer) this.gl.deleteBuffer(this.tiledataBuffer);
+        if (this.atlasTexture) this.gl.deleteTexture(this.atlasTexture);
+
+        if (this.program) {
+            const shaders = this.gl.getAttachedShaders(this.program);
+            if (shaders) {
+                shaders.forEach(shader => {
+                    this.gl.deleteShader(shader);
+                });
+            }
+            this.gl.deleteProgram(this.program);
+        }
+
+        this.vertexBuffer = null;
+        this.tiledataBuffer = null;
+        this.atlasTexture = null;
+        this.program = null;
+        this.locations = null;
+
+        if (this.gl) {
+            this.gl.clearColor(0, 0, 0, 1);
+            this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
+
+            if (this.gl.getExtension('WEBGL_lose_context')) {
+                this.gl.getExtension('WEBGL_lose_context').loseContext();
+            }
+        }
+        this.gl = null;
+    }
+}

--- a/src/interfaces/IRenderer.ts
+++ b/src/interfaces/IRenderer.ts
@@ -27,6 +27,10 @@ export interface IRenderer {
     // Add event handling
     on(event: 'error' | 'ready' | 'disposed', callback: (data?: any) => void): void;
     off(event: string, callback: (data?: any) => void): void;
+
+    // WebGL2-specific methods and properties
+    updateGridData(data: Uint8Array): void;
+    handleResize(): void;
 }
 
 export type RendererError = {
@@ -143,4 +147,3 @@ export abstract class RendererLayer {
 
     protected abstract validate(data: Uint8Array): boolean;
 }
-

--- a/wwwroot/engine/game.js
+++ b/wwwroot/engine/game.js
@@ -3,6 +3,7 @@ import { WebGPURenderer } from './renderer/WebGPU-renderer.js';
 import { WebGL2Renderer } from './renderer/WebGL2-renderer.js';
 import { Canvas2DRenderer } from './renderer/Canvas2D-renderer.js';
 import { ConnectionManager } from './connection-manager.js';
+import { WEBGL2Renderer } from './WEBGL2Renderer.js';
 
 export class Game {
     constructor() {
@@ -146,6 +147,10 @@ export class Game {
             console.log('WebGL2 is supported');
             return new WebGL2Renderer(this.canvas, this.viewportSize);
         }
+        if (WEBGL2Renderer.isSupported()) {
+            console.log('WEBGL2 is supported');
+            return new WEBGL2Renderer(this.canvas, this.viewportSize);
+        }
         if (Canvas2DRenderer.isSupported()) {
             console.log('Canvas2D is supported');
             return new Canvas2DRenderer(this.canvas, this.viewportSize);
@@ -194,6 +199,13 @@ export class Game {
                         throw new Error('WebGL2 not supported');
                     }
                     this.renderer = new WebGL2Renderer(this.canvas, this.viewportSize);
+                    break;
+
+                case 'WEBGL2':
+                    if (!WEBGL2Renderer.isSupported()) {
+                        throw new Error('WEBGL2 not supported');
+                    }
+                    this.renderer = new WEBGL2Renderer(this.canvas, this.viewportSize);
                     break;
     
                 case 'Canvas2D':


### PR DESCRIPTION
Add WebGL2 support for the new renderer system and complete WebGL2 version of TerrainPass.

* **Add `src/WEBGL2Renderer.ts`**:
  - Implement `WEBGL2Renderer` class with methods for setup, buffer creation, shader creation, uniforms and attributes, update methods, draw method, and dispose method.
  - Include static method `isSupported` to check WebGL2 support.

* **Add `src/WEBGL2TerrainPass.ts`**:
  - Implement `WEBGL2TerrainPass` class with methods for setup, buffer creation, shader creation, uniforms and attributes, update methods, draw method, and dispose method.

* **Modify `wwwroot/engine/game.js`**:
  - Import `WEBGL2Renderer`.
  - Update `selectRenderer` and `changeRenderer` methods to include `WEBGL2Renderer`.

* **Modify `src/interfaces/IRenderer.ts`**:
  - Add WebGL2-specific methods and properties to `IRenderer` interface.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Uggeli/WebPeli/pull/15?shareId=1fe5f43b-b842-421c-afe9-82a318e6ddcc).